### PR TITLE
[simon] Github logo redirect new tab.

### DIFF
--- a/Angular/src/app/about/about.component.html
+++ b/Angular/src/app/about/about.component.html
@@ -15,7 +15,7 @@
         </div>
         <div class="col-md-12 mt-3">
           <h3>GitHub</h3>
-          <a href="https://github.com/Bojo992/CS4116-DatingApp">
+          <a href="https://github.com/Bojo992/CS4116-DatingApp" target="_blank">
             <img src="assets/githubLogo.png" alt="GitHub Logo">
           </a>
         </div>


### PR DESCRIPTION
Redirect user to new tab rather than overriding our website when clicking on github logo in about.component.
![Spider-bug](https://github.com/Bojo992/CS4116-DatingApp/assets/102541413/6319bd4e-2603-4fda-99e6-61ac1bfeb2b5)
